### PR TITLE
core: add a kernel_symbol module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
 name = "packet-tracer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bimap",
+ "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+bimap = "0.6"
+once_cell = "1.15"

--- a/src/core/kernel_symbols.rs
+++ b/src/core/kernel_symbols.rs
@@ -1,0 +1,143 @@
+//! # Kernel symbols
+//!
+//! Interface to query the kernel symbol addresses / name relationship, both
+//! ways. It does so by parsing /proc/kallsyms and by using a singleton
+//! initialized on-demand.
+
+// Internal library, some helpers might not be used, that's fine.
+#![allow(dead_code)]
+
+use std::fs;
+
+use anyhow::{anyhow, bail, Result};
+use bimap::BiHashMap;
+use once_cell::sync::OnceCell;
+
+/// Path to the kernel symbols file. It should be under /proc/kallsyms (and this
+/// is the default, see below). To allow unit tests to run, as /proc/kallsyms
+/// might vary and requires privileged access, a OnceCell is used to allow unit
+/// tests to override it.
+static KALLSYMS: OnceCell<String> = OnceCell::new();
+
+/// Kernel symbols bidirectional map. To retrieve it, please use:
+/// ```
+/// let symbols = get_symbols!().unwrap();
+/// ```
+static SYMBOLS: OnceCell<BiHashMap<u64, String>> = OnceCell::new();
+
+/// Return a reference to the symbol map and initialize it on first access. To
+/// set the initial values, KALLSYMS is parsed as it contains the kernel symbol
+/// addr<>name relationships.
+macro_rules! get_symbols {
+    () => {
+        SYMBOLS.get_or_try_init(|| {
+            let kallsyms_file = KALLSYMS.get_or_init(|| String::from("/proc/kallsyms"));
+            let file = fs::read_to_string(kallsyms_file)?;
+            let mut map = BiHashMap::new();
+
+            for line in file.lines() {
+                let data: Vec<&str> = line.split(' ').collect();
+                if data.len() < 3 {
+                    bail!("Invalid kallsyms line: {}", line);
+                }
+
+                let symbol: &str = data[2]
+                    .split('\t')
+                    .next()
+                    .ok_or(anyhow!("Couldn't get symbol name for {}", data[0]))?;
+
+                map.insert(u64::from_str_radix(data[0], 16)?, String::from(symbol));
+            }
+
+            Ok(map)
+        })
+    };
+}
+
+/// Return a symbol name given its address, if a relationship is found.
+pub(crate) fn get_symbol_name(addr: u64) -> Result<String> {
+    Ok(get_symbols!()?
+        .get_by_left(&addr)
+        .ok_or(anyhow!("Can't get symbol name for {}", addr))?
+        .clone())
+}
+
+/// Return a symbol address given its name, if a relationship is found.
+pub(crate) fn get_symbol_addr(name: &str) -> Result<u64> {
+    Ok(*get_symbols!()?
+        .get_by_right(name)
+        .ok_or(anyhow!("Can't get symbol address for {}", name))?)
+}
+
+/// Given an address, try to find the nearest symbol, if any.
+pub(crate) fn find_nearest_symbol(target: u64) -> Result<u64> {
+    let (mut nearest, mut best_score) = (0, std::u64::MAX);
+
+    for addr in get_symbols!()?.left_values() {
+        // The target address has to be greater or equal to a symbol address to
+        // be considered near it (and part of it).
+        if target < *addr {
+            continue;
+        }
+
+        let score = target.abs_diff(*addr);
+        if score < best_score {
+            nearest = *addr;
+            best_score = score;
+
+            // Exact match; can't do better than that.
+            if score == 0 {
+                break;
+            }
+        }
+    }
+
+    if best_score == std::u64::MAX {
+        bail!("Can't get a symbol near {}", target);
+    }
+
+    Ok(nearest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init() {
+        KALLSYMS.get_or_init(|| String::from("test_data/kallsyms"));
+    }
+
+    #[test]
+    fn symbol_name() {
+        init();
+        assert!(get_symbol_name(0xffffffff95617530).unwrap() == "consume_skb");
+    }
+
+    #[test]
+    fn symbol_addr() {
+        init();
+        assert!(get_symbol_addr("consume_skb").unwrap() == 0xffffffff95617530);
+    }
+
+    #[test]
+    fn test_bijection() {
+        init();
+
+        let symbol = "consume_skb";
+        let addr = get_symbol_addr(symbol).unwrap();
+        let name = get_symbol_name(addr).unwrap();
+
+        assert!(symbol == name);
+    }
+
+    #[test]
+    fn nearest_symbol() {
+        init();
+
+        let addr = get_symbol_addr("consume_skb").unwrap();
+
+        assert!(find_nearest_symbol(addr + 1).unwrap() == addr);
+        assert!(find_nearest_symbol(addr).unwrap() == addr);
+        assert!(find_nearest_symbol(addr - 1).unwrap() != addr);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,6 @@
+//! # Core
+//!
+//! Core module, providing tools and common logic that can be used by any module
+//! within the tool.
+
+pub(crate) mod kernel_symbols;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 
+pub(crate) mod core;
+
 fn main() -> Result<()> {
     Ok(())
 }


### PR DESCRIPTION
Simple interface to get kernel symbols addresses from their name and the opposite. This will be useful for probing the kernel, from configuring kprobes to understanding where an event is coming from.