### PR TITLE
Extend probe runtime inspection and provide parameter offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "btf-rs"
 version = "0.1.0"
-source = "git+https://github.com/net-trace/btf-rs#a8ffd76a4b21c1aaa735af380241bb0300fc8cfb"
+source = "git+https://github.com/net-trace/btf-rs#15aea1f65fed82e6a50e0ff68be98cbf8c9fde20"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -331,9 +331,11 @@ dependencies = [
  "btf-rs",
  "libbpf-cargo",
  "libbpf-rs",
+ "libbpf-sys",
  "log",
  "memmap2",
  "once_cell",
+ "plain",
 ]
 
 [[package]]
@@ -341,6 +343,12 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ anyhow = "1.0"
 bimap = "0.6"
 btf-rs = {git = "https://github.com/net-trace/btf-rs"}
 libbpf-rs = "0.19"
+libbpf-sys = "1.0"
 log = "0.4"
 once_cell = "1.15"
+plain = "0.2"
 
 [build-dependencies]
 libbpf-cargo = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,8 @@ fn build_hook(source: &str) {
         obj
     )
     .unwrap();
+
+    println!("cargo:rerun-if-changed={}", source);
 }
 
 fn build_probe(source: &str) {

--- a/src/core/probe/kernel/config.rs
+++ b/src/core/probe/kernel/config.rs
@@ -1,0 +1,52 @@
+use std::mem;
+
+use anyhow::Result;
+
+/// Per-probe parameter offsets; keep in sync with its BPF counterpart in
+/// bpf/include/common.h
+#[repr(C)]
+pub(super) struct ProbeOffsets {
+    pub(super) sk_buff: i8,
+    pub(super) skb_drop_reason: i8,
+    pub(super) net_device: i8,
+    pub(super) net: i8,
+}
+
+impl Default for ProbeOffsets {
+    fn default() -> ProbeOffsets {
+        // -1 means the argument isn't available.
+        ProbeOffsets {
+            sk_buff: -1,
+            skb_drop_reason: -1,
+            net_device: -1,
+            net: -1,
+        }
+    }
+}
+
+/// Per-probe configuration; keep in sync with its BPF counterpart in
+/// bpf/include/common.h
+#[derive(Default)]
+#[repr(C)]
+pub(super) struct ProbeConfig {
+    pub(super) offsets: ProbeOffsets,
+}
+
+unsafe impl plain::Plain for ProbeConfig {}
+
+#[allow(dead_code)] // When testing this isn't used as the config map is hidden.
+pub(super) fn init_config_map() -> Result<libbpf_rs::Map> {
+    let opts = libbpf_sys::bpf_map_create_opts {
+        sz: mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        ..Default::default()
+    };
+
+    Ok(libbpf_rs::Map::create(
+        libbpf_rs::MapType::Hash,
+        Some("config_map"),
+        mem::size_of::<u64>() as u32,
+        mem::size_of::<ProbeConfig>() as u32,
+        super::PROBE_MAX as u32,
+        &opts,
+    )?)
+}


### PR DESCRIPTION
The two first commits are small fixes.

The last one extends the runtime inspection of symbols (functions/tracepoints) to dynamically check if given parameters are available and if so to provide their offsets to the BPF probes.

The extra information is then used in BPF to add helpers to easily retrieve known parameters, e.g.

```
struct sk_buff *skb = trace_get_sk_buff(ctx);
if (!skb)
        return 0;
[...]
```

Current known parameters: `struct sk_buff *`, `enum skb_drop_reason`, `struct net_device *`, `struct net *`.

An helper is also added for collectors to inspect function & tracepoints at runtime, e.g.

```
let skb = kernel.function_parameter_offset(ProbeType::Kprobe, "skb_free_reason", "struct sk_buff *")?.is_some();
```

Based on #22 .