### PR TITLE
Allow hooks to reuse their own maps

### DIFF
--- a/src/core/probe/kernel/kernel.rs
+++ b/src/core/probe/kernel/kernel.rs
@@ -69,7 +69,7 @@ pub(crate) struct Kernel {
 }
 
 // Keep in sync with their BPF counterparts in bpf/include/common.h
-pub(super) const PROBE_MAX: usize = 128; // TODO add checks on probe registration.
+pub(crate) const PROBE_MAX: usize = 128; // TODO add checks on probe registration.
 pub(super) const HOOK_MAX: usize = 10;
 
 struct ProbeSet {

--- a/src/core/probe/kernel/kprobe.rs
+++ b/src/core/probe/kernel/kprobe.rs
@@ -24,7 +24,7 @@ impl ProbeBuilder for KprobeBuilder {
         KprobeBuilder::default()
     }
 
-    fn init(&mut self, map_fds: Vec<(String, i32)>, hooks: Vec<&'static [u8]>) -> Result<()> {
+    fn init(&mut self, map_fds: Vec<(String, i32)>, hooks: Vec<Hook>) -> Result<()> {
         if self.obj.is_some() {
             bail!("Kprobe builder already initialized");
         }

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -18,7 +18,7 @@ use raw_tracepoint_bpf::RawTracepointSkelBuilder;
 pub(super) struct RawTracepointBuilder {
     links: Vec<libbpf_rs::Link>,
     map_fds: Vec<(String, i32)>,
-    hooks: Vec<&'static [u8]>,
+    hooks: Vec<Hook>,
 }
 
 impl ProbeBuilder for RawTracepointBuilder {
@@ -26,7 +26,7 @@ impl ProbeBuilder for RawTracepointBuilder {
         RawTracepointBuilder::default()
     }
 
-    fn init(&mut self, map_fds: Vec<(String, i32)>, hooks: Vec<&'static [u8]>) -> Result<()> {
+    fn init(&mut self, map_fds: Vec<(String, i32)>, hooks: Vec<Hook>) -> Result<()> {
         self.map_fds = map_fds;
         self.hooks = hooks;
         Ok(())


### PR DESCRIPTION
With this collectors can register maps and let their hooks reuse the maps fds. This will help in having per-collector/hook maps for retrieving specific information or retrieving configuration in the BPF part.