### PR TITLE
Track skbs using a dedicated collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "libbpf-sys",
- "nix",
+ "nix 0.24.2",
  "num_enum",
  "strum_macros",
  "thiserror",
@@ -347,6 +347,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +406,16 @@ dependencies = [
  "libbpf-sys",
  "log",
  "memmap2",
+ "nix 0.25.0",
  "once_cell",
  "plain",
 ]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.0", features = ["derive", "string"] }
 libbpf-rs = "0.19"
 libbpf-sys = "1.0"
 log = "0.4"
+nix = "0.25"
 once_cell = "1.15"
 plain = "0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -71,5 +71,8 @@ fn main() {
     build_probe("src/core/probe/kernel/bpf/kprobe.bpf.c");
     build_probe("src/core/probe/kernel/bpf/raw_tracepoint.bpf.c");
 
+    // collector::skb_tracking
+    build_hook("src/collector/skb_tracking/bpf/tracking_hook.bpf.c");
+
     println!("cargo:rerun-if-changed={}", INCLUDE_PATH);
 }

--- a/src/collector/collector.rs
+++ b/src/collector/collector.rs
@@ -89,7 +89,7 @@ impl Group {
             let c = self
                 .list
                 .get_mut(name)
-                .ok_or_else(|| anyhow!(format!("unknown collector: {}", &name)))?;
+                .ok_or_else(|| anyhow!("unknown collector: {}", &name))?;
             if let Err(e) = c.init(cli, &mut self.kernel) {
                 to_remove.push(c.name());
                 error!(

--- a/src/collector/collector.rs
+++ b/src/collector/collector.rs
@@ -5,6 +5,7 @@ use log::{error, warn};
 
 use super::ovs::OvsCollector;
 use super::skb::SkbCollector;
+use super::skb_tracking::SkbTrackingCollector;
 use crate::cli::{cmd::collect::Collect, dynamic::DynamicCommand, CliConfig};
 use crate::core::probe;
 
@@ -141,6 +142,7 @@ pub(crate) fn get_collectors() -> Result<Group> {
 
     // Register all collectors here.
     group
+        .register(Box::new(SkbTrackingCollector::new()?))?
         .register(Box::new(SkbCollector::new()?))?
         .register(Box::new(OvsCollector::new()?))?;
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -22,3 +22,4 @@ pub(crate) use collector::*;
 
 mod ovs;
 mod skb;
+mod skb_tracking;

--- a/src/collector/ovs/ovs.rs
+++ b/src/collector/ovs/ovs.rs
@@ -18,7 +18,7 @@ impl Collector for OvsCollector {
     }
 
     fn register_cli(&self, cmd: &mut DynamicCommand) -> Result<()> {
-        cmd.register_module_noargs("ovs")
+        cmd.register_module_noargs(OVS_COLLECTOR)
     }
 
     fn init(&mut self, _: &CliConfig, _kernel: &mut kernel::Kernel) -> Result<()> {

--- a/src/collector/skb/skb.rs
+++ b/src/collector/skb/skb.rs
@@ -4,6 +4,8 @@ use crate::cli::{dynamic::DynamicCommand, CliConfig};
 use crate::collector::Collector;
 use crate::core::probe::kernel;
 
+const SKB_COLLECTOR: &str = "skb";
+
 pub(in crate::collector) struct SkbCollector {}
 
 impl Collector for SkbCollector {
@@ -12,11 +14,11 @@ impl Collector for SkbCollector {
     }
 
     fn name(&self) -> &'static str {
-        "skb"
+        SKB_COLLECTOR
     }
 
     fn register_cli(&self, cmd: &mut DynamicCommand) -> Result<()> {
-        cmd.register_module_noargs("skb")
+        cmd.register_module_noargs(SKB_COLLECTOR)
     }
 
     fn init(&mut self, _: &CliConfig, _kernel: &mut kernel::Kernel) -> Result<()> {

--- a/src/collector/skb_tracking/bpf/tracking_hook.bpf.c
+++ b/src/collector/skb_tracking/bpf/tracking_hook.bpf.c
@@ -1,0 +1,139 @@
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+
+#include <common.h>
+
+/* Tracking configuration to provide hints about what the probed function does
+ * for some special handling scenarios.
+ *
+ * Indexed in the tracking_config_map by the function ksym address.
+ *
+ * Please keep in sync with its Rust counterpart in collector::skb_tracking.
+ */
+struct tracking_config {
+	/* Function is freeing skbs */
+	u8 free;
+	/* Function is invalidating the head of skbs */
+	u8 inv_head;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, PROBE_MAX);
+	__type(key, u64);
+	__type(value, struct tracking_config);
+} tracking_config_map SEC(".maps");
+
+/* The tracking_info structure stores information on known skbs. It is indexed
+ * in the tracking_map by the skb data address (and in some temporary cases by
+ * the skb address directly).
+ *
+ * In order to uniquely identify skbs, the tuple (addr, timestamp) is used and
+ * must be reported as part of all events (TODO).
+ *
+ * Please keep in sync with its Rust counterpart in collector::skb_tracking.
+ */
+struct tracking_info {
+	/* When the skb was first seen */
+	u64 timestamp;
+	/* When the skb was last seen */
+	u64 last_seen;
+	/* Original head address; useful when the head is invalidated */
+	u64 orig_head;
+} __attribute__((packed));
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u64);
+	__type(value, struct tracking_info);
+} tracking_map SEC(".maps");
+
+/* Must be called with a valid skb pointer */
+static __always_inline int track_skb(struct trace_context *ctx,
+				     struct sk_buff *skb)
+{
+	enum skb_drop_reason drop_reason = 0;
+	struct tracking_info *ti = NULL, new;
+	bool free = false, inv_head = false;
+	struct tracking_config *cfg;
+	u64 head, ksym = ctx->ksym;
+
+	/* Try to retrieve the tracking configuration for this symbol. Only
+	 * specific ones will be found while we want to track skb in all
+	 * functions taking an skb as a parameter. When no tracking
+	 * configuration is found, the function being probed is just quite
+	 * generic.
+	 */
+	cfg = bpf_map_lookup_elem(&tracking_config_map, &ksym);
+	if (cfg) {
+		free = cfg->free;
+		inv_head = cfg->inv_head;
+	}
+
+	head = (u64)BPF_CORE_READ(skb, head);
+	if (!head)
+		return 0;
+
+	ti = bpf_map_lookup_elem(&tracking_map, &head);
+
+	/* No tracking info was found for this skb. */
+	if (!ti) {
+		/* It might be temporarily stored it using its skb address. */
+		ti = bpf_map_lookup_elem(&tracking_map, (u64 *)&skb);
+		if (ti) {
+			/* If found, index it by its data address from now on,
+			 * as others.
+			 */
+			bpf_map_delete_elem(&tracking_map, (u64 *)&skb);
+			bpf_map_update_elem(&tracking_map, &head, ti,
+					    BPF_NOEXIST);
+		}
+	}
+
+	/* Still NULL, this is the first time we see this skb. Create a new
+	 * tracking info.
+	 */
+	if (!ti) {
+		ti = &new;
+		ti->timestamp = ctx->timestamp;
+		ti->last_seen = ctx->timestamp;
+		ti->orig_head = head;
+
+		/* No need to globally track it if the first time we see this
+		 * skb is when it is freed.
+		 */
+		if (!free)
+			bpf_map_update_elem(&tracking_map, &head, &new,
+					    BPF_NOEXIST);
+	}
+
+	/* Track when we last saw this skb, as it'll be useful to garbage
+	 * collect tracking map entries if we miss some events.
+	 */
+	ti->last_seen = ctx->timestamp;
+
+	/* If the function invalidates the skb head, we can't know what will be
+	 * the new head value. Temporarily track the skb using its skb address.
+	 */
+	if (inv_head)
+		bpf_map_update_elem(&tracking_map, (u64 *)&skb, ti, BPF_NOEXIST);
+	/* If the skb is freed, remove it from our tracking list. */
+	else if (free)
+		bpf_map_delete_elem(&tracking_map, &head);
+
+	if (trace_arg_valid(ctx, skb_drop_reason))
+		drop_reason = trace_get_skb_drop_reason(ctx);
+
+	return 0;
+}
+
+DEFINE_HOOK(
+	struct sk_buff *skb;
+
+	skb = trace_get_sk_buff(ctx);
+	if (!skb)
+		return 0;
+
+	return track_skb(ctx, skb);
+)
+
+char __license[] SEC("license") = "GPL";

--- a/src/collector/skb_tracking/mod.rs
+++ b/src/collector/skb_tracking/mod.rs
@@ -1,0 +1,88 @@
+//! # SkbCollector
+//!
+//! One important goal of this tool is to follow packets in the stack, by
+//! generating events at various points in the networking stack. To reconstruct
+//! the flow of packets a way to uniquely identify them is more than needed.
+//! Here we're targeting `struct sk_buff` and aim at generating unique
+//! identifiers.
+//!
+//! The kernel does not offer such facility.
+//!
+//! Note: as the kernel changes, compilation decisions (which functions are
+//! inlined for example) and internal API might change. For this reason making a
+//! 100% accurate solution might not be possible and we chose to explicitly take
+//! a safer path: trying hard to make the unique identifier work but leave room
+//! for uncertainty.
+//!
+//! ## Unique identifier
+//!
+//! The socket buffer contains various metadata and a pointer to a memory area
+//! used to store its data (`skb->head`). As moving data around is costly, this
+//! memory area location is rarely changed during the lifetime of an skb. Also
+//! the skb address itself is too volatile (clones, etc) to be stable in time.
+//! The data location is a good candidate for the unique identifier.
+//!
+//! But using this alone wouldn't work as this memory location, after being
+//! freed, might be reused at a later time and we would have two different
+//! packets sharing the same id. To solve this issue we propose to:
+//!
+//! - Use the timestamp of the first time we saw a (unique) packet in its id.
+//! - Track when a packet data is being freed and thus is available for reuse.
+//! - Track the rare cases when the data location changes (for example when
+//!   extending the data area) and reuse the initial data location in the id.
+//!
+//! The unique identifier is thus `(original_skb_head << 64 | initial_timestamp)`.
+//!
+//!
+//! ## Clones
+//!
+//! Socket buffers can be cloned and we end up with multiple skb objects
+//! pointing to the same data area. In such cases we'd still like to track those
+//! as being the same packet while allowing to distinguish them. One easy way is
+//! to provide the skb own address. We end up reporting `(unique_id, &skb)`.
+//!
+//! ## Internal tracking
+//!
+//! While the events will report `((original_skb_head << 64 | initial_timestamp), &skb)`
+//! we can't directly use this in the kernel to track packets. We can however
+//! directly use the data addresses as we know at a given point in time they'll
+//! belong to a single packet. Thus to track packets we're using a map and the
+//! data addresses as keys. The data itself contains metadata, including the
+//! unique id itself).
+//!
+//! ## Proposed solution
+//!
+//! 1. We don't need to react to allocation events specifically. A packet will
+//!    be matched at some point and we can consider this as the initial event
+//!    triggering the identification logic. It's not an issue as we're not
+//!    refcounting the packets ourselves.
+//!
+//! 2. We don't need to react to clone events as the data address won't change
+//!    and we'll be reusing the unique id. A new skb will show in the logs and
+//!    we'll be able to both identify it as being part of the flow and as being
+//!    a clone (different skb address). Fast clones are not special either.
+//!
+//! 3. To track data address modifications we need to map those packets to the
+//!    original unique id. In addition, we can't know the new data location when
+//!    it is being modified and we need a temporary one until we see the packet
+//!    again (with its new data address). For this we'll use the skb address
+//!    directly.
+//!
+//!    Notes:
+//!    - This can't conflict with other keys (key are all memory addresses).
+//!    - If the data modification function fails and we don't track this, a
+//!      stale entry will stay until being garbage collected (see below).
+//!
+//! 4. When the data area is freed (or marked for reuse) we should stop tracking
+//!    it. As we allow to miss some events to have a more robust design, we're
+//!    garbage collecting old events from the tracking map (such events should
+//!    be fairly rare, otherwise it's a bug).
+
+// Re-export skb_tracking.rs
+#[allow(clippy::module_inception)]
+pub(super) mod skb_tracking;
+pub(super) use skb_tracking::*;
+
+mod tracking_hook {
+    include!("bpf/.out/tracking_hook.rs");
+}

--- a/src/collector/skb_tracking/skb_tracking.rs
+++ b/src/collector/skb_tracking/skb_tracking.rs
@@ -1,0 +1,224 @@
+use std::{mem, thread, time::Duration};
+
+use anyhow::{bail, Result};
+use log::{error, info, warn};
+use nix::time;
+use plain::Plain;
+
+use super::tracking_hook;
+use crate::{
+    cli::{dynamic::DynamicCommand, CliConfig},
+    collector::Collector,
+    core::{
+        probe::kernel::{self, Hook, ProbeType},
+        workaround::SendableMap,
+    },
+};
+
+const SKB_TRACKING_COLLECTOR: &str = "skb-tracking";
+
+// GC runs in a thread every SKB_TRACKING_GC_INTERVAL seconds to collect and
+// remove old entries.
+const SKB_TRACKING_GC_INTERVAL: u64 = 5;
+
+// Time in seconds after entries in the skb tracking map are considered outdated
+// and should be manually removed. It's a tradeoff between having consistent
+// data and not having the map full of old entries. However, this logic
+// shouldn't happen much — or it is a bug.
+const TRACKING_OLD_LIMIT: u64 = 60;
+
+#[derive(Default)]
+pub(in crate::collector) struct SkbTrackingCollector {
+    garbage_collector: Option<thread::JoinHandle<()>>,
+}
+
+impl Collector for SkbTrackingCollector {
+    fn new() -> Result<SkbTrackingCollector> {
+        Ok(SkbTrackingCollector::default())
+    }
+
+    fn name(&self) -> &'static str {
+        SKB_TRACKING_COLLECTOR
+    }
+
+    fn register_cli(&self, cmd: &mut DynamicCommand) -> Result<()> {
+        cmd.register_module_noargs(SKB_TRACKING_COLLECTOR)
+    }
+
+    fn init(&mut self, _: &CliConfig, kernel: &mut kernel::Kernel) -> Result<()> {
+        self.init_tracking(kernel)?;
+
+        // We'd like to track free reasons as well.
+        let res = kernel
+            .inspect
+            .is_symbol_traceable(&ProbeType::Kprobe, "kfree_skb_reason");
+        if let Err(e) = kernel.add_probe(ProbeType::Kprobe, "kfree_skb_reason") {
+            // Did the probe failed because of an error or because it wasn't
+            // available? In case we can't know, do not issue an error.
+            let mut is_error = false;
+            if let Some(traceable) = res {
+                if traceable {
+                    is_error = true;
+                }
+            }
+
+            match is_error {
+                true => error!("Could not attach to kfree_skb_reason: {}", e),
+                false => info!("Skb drop reasons are not retrievable on this kernel"),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn start(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl SkbTrackingCollector {
+    fn tracking_config_map() -> Result<libbpf_rs::Map> {
+        let opts = libbpf_sys::bpf_map_create_opts {
+            sz: mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+            ..Default::default()
+        };
+
+        // Please keep in sync with its BPF counterpart in
+        // bpf/tracking_hook.ebpf.c
+        libbpf_rs::Map::create(
+            libbpf_rs::MapType::Hash,
+            Some("tracking_config_map"),
+            mem::size_of::<u64>() as u32,
+            mem::size_of::<TrackingConfig>() as u32,
+            kernel::PROBE_MAX as u32,
+            &opts,
+        )
+        .or_else(|e| bail!("Could not create the tracking config map: {}", e))
+    }
+
+    fn tracking_map() -> Result<libbpf_rs::Map> {
+        let opts = libbpf_sys::bpf_map_create_opts {
+            sz: mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+            ..Default::default()
+        };
+
+        // Please keep in sync with its BPF counterpart in
+        // bpf/tracking_hook.ebpf.c
+        libbpf_rs::Map::create(
+            libbpf_rs::MapType::Hash,
+            Some("tracking_map"),
+            mem::size_of::<u64>() as u32,
+            mem::size_of::<TrackingInfo>() as u32,
+            8192,
+            &opts,
+        )
+        .or_else(|e| bail!("Could not create the tracking map: {}", e))
+    }
+
+    fn init_tracking(&mut self, kernel: &mut kernel::Kernel) -> Result<()> {
+        let mut tracking_config_map = Self::tracking_config_map()?;
+        let mut tracking_map = SendableMap::from(Self::tracking_map()?);
+        let tracking_fd = tracking_map.get().fd();
+
+        // Register the tracking hook to all probes.
+        kernel.register_hook(
+            Hook::from(tracking_hook::DATA)
+                .reuse_map("tracking_config_map", tracking_config_map.fd())?
+                .reuse_map("tracking_map", tracking_fd)?
+                .to_owned(),
+        )?;
+
+        // For tracking skbs we only need the following two functions. First
+        // track free events.
+        let key = kernel
+            .inspect
+            .get_ksym(&ProbeType::Kprobe, "skb_free_head")?
+            .to_ne_bytes();
+        let cfg = TrackingConfig {
+            free: 1,
+            inv_head: 0,
+        };
+        let cfg = unsafe { plain::as_bytes(&cfg) };
+        tracking_config_map.update(&key, cfg, libbpf_rs::MapFlags::NO_EXIST)?;
+        kernel.add_probe(ProbeType::Kprobe, "skb_free_head")?;
+
+        // Then track invalidation head events.
+        let key = kernel
+            .inspect
+            .get_ksym(&ProbeType::Kprobe, "pskb_expand_head")?
+            .to_ne_bytes();
+        let cfg = TrackingConfig {
+            free: 0,
+            inv_head: 1,
+        };
+        let cfg = unsafe { plain::as_bytes(&cfg) };
+        tracking_config_map.update(&key, cfg, libbpf_rs::MapFlags::NO_EXIST)?;
+        kernel.add_probe(ProbeType::Kprobe, "pskb_expand_head")?;
+
+        // Take care of gargabe collection of tracking info. This should be done
+        // in the BPF part for most if not all skbs but we might lose some
+        // information (and tracked functions might fail resulting in incorrect
+        // information).
+        self.garbage_collector = Some(thread::spawn(move || {
+            let tracking_map = tracking_map.get_mut();
+
+            loop {
+                // Let's run every SKB_TRACKING_GC_INTERVAL seconds.
+                thread::sleep(Duration::from_secs(SKB_TRACKING_GC_INTERVAL));
+                let now =
+                    Duration::from(time::clock_gettime(time::ClockId::CLOCK_MONOTONIC).unwrap());
+
+                // Loop through the tracking map entries and see if we see old
+                // ones we should remove manually.
+                let mut to_remove = Vec::new();
+                for key in tracking_map.keys() {
+                    if let Ok(Some(raw)) = tracking_map.lookup(&key, libbpf_rs::MapFlags::ANY) {
+                        // Get the tracking info associated with the entry.
+                        let mut info = TrackingInfo::default();
+                        plain::copy_from_bytes(&mut info, &raw[..]).unwrap();
+
+                        // Remove old entries. Actually put them on a remove
+                        // list as we can't live remove them here (we already
+                        // have a reference to the map).
+                        let last_seen = Duration::from_nanos(info.last_seen);
+                        if now.saturating_sub(last_seen) > Duration::from_secs(TRACKING_OLD_LIMIT) {
+                            to_remove.push(key);
+                        }
+                    }
+                }
+
+                // Actually remove the outdated entries and issue a warning as
+                // while it can be expected, it should not happen too often.
+                for key in to_remove {
+                    tracking_map.delete(&key).ok();
+                    warn!(
+                        "Removed old entry from skb tracking map: {:#x}",
+                        u64::from_ne_bytes(key[..8].try_into().unwrap())
+                    );
+                }
+            }
+        }));
+
+        Ok(())
+    }
+}
+
+// Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
+#[repr(C)]
+struct TrackingConfig {
+    free: u8,
+    inv_head: u8,
+}
+
+unsafe impl Plain for TrackingConfig {}
+
+// Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
+#[derive(Default)]
+#[repr(C)]
+struct TrackingInfo {
+    timestamp: u64,
+    last_seen: u64,
+    orig_head: u64,
+}
+
+unsafe impl Plain for TrackingInfo {}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,3 +5,4 @@
 
 pub(crate) mod kernel_symbols;
 pub(crate) mod probe;
+pub(crate) mod workaround;

--- a/src/core/probe/kernel/inspect.rs
+++ b/src/core/probe/kernel/inspect.rs
@@ -1,0 +1,272 @@
+#![allow(dead_code)] // FIXME
+
+use anyhow::{bail, Result};
+use btf_rs::{Btf, Type};
+
+use super::{config::ProbeConfig, ProbeType};
+use crate::core::kernel_symbols;
+
+#[derive(Default)]
+pub(super) struct TargetDesc {
+    pub(super) ksym: u64,
+    pub(super) nargs: u32,
+    pub(super) probe_cfg: ProbeConfig,
+}
+
+/// Provides helpers to inspect probe related information in the kernel.
+pub(crate) struct Inspector {
+    btf: Btf,
+}
+
+impl Inspector {
+    pub(crate) fn new() -> Result<Inspector> {
+        Ok(Inspector {
+            #[cfg(not(test))]
+            btf: Btf::from_file("/sys/kernel/btf/vmlinux")?,
+            #[cfg(test)]
+            btf: Btf::from_file("test_data/vmlinux")?,
+        })
+    }
+
+    /// Get a parameter offset given its type in a given kernel function, if
+    /// any. Can be used to check a function has a given parameter by using
+    /// `function_parameter_offset()?.is_some()`
+    pub(crate) fn function_parameter_offset(
+        &self,
+        r#type: ProbeType,
+        target: &str,
+        parameter_type: &str,
+    ) -> Result<Option<u32>> {
+        // Raw tracepoints have a void* pointing to the data as their first
+        // argument, which does not end up in their context. We have to skip it.
+        // See include/trace/bpf_probe.h in the __DEFINE_EVENT definition.
+        let fix = match r#type {
+            ProbeType::RawTracepoint => 1,
+            _ => 0,
+        };
+
+        let proto = self.get_function_prototype(&r#type, target)?;
+        for (offset, param) in proto.parameters.iter().enumerate() {
+            if self.is_param_type(param, parameter_type)? {
+                if offset < fix {
+                    continue;
+                }
+                return Ok(Some((offset - fix) as u32));
+            }
+        }
+        Ok(None)
+    }
+
+    fn get_function_prototype(
+        &self,
+        r#type: &ProbeType,
+        target: &str,
+    ) -> Result<btf_rs::FuncProto> {
+        // Some probe types might need to change the target format.
+        Ok(match r#type {
+            ProbeType::Kprobe => {
+                // Kprobes are using directly the target function definition, no
+                // change to make to the target format and the prototype
+                // resolution is straightforward: Func -> FuncProto.
+                let func = match self.btf.resolve_type_by_name(target)? {
+                    Type::Func(func) => func,
+                    _ => bail!("{} is not a function", target),
+                };
+
+                match self.btf.resolve_chained_type(&func)? {
+                    Type::FuncProto(proto) => proto,
+                    _ => bail!("Function {} does not have a prototype", target),
+                }
+            }
+            ProbeType::RawTracepoint => {
+                // Raw tracepoints need to access a symbol derived from
+                // TP_PROTO(), which is named "btf_trace_<func>". The prototype
+                // resolution is: Typedef -> Ptr -> FuncProto.
+                let target = format!("btf_trace_{}", target);
+
+                let func = match self.btf.resolve_type_by_name(target.as_str())? {
+                    Type::Typedef(func) => func,
+                    _ => bail!("{} is not a typedef", target),
+                };
+
+                let ptr = match self.btf.resolve_chained_type(&func)? {
+                    Type::Ptr(ptr) => ptr,
+                    _ => bail!("{} typedef does not point to a ptr", target),
+                };
+
+                match self.btf.resolve_chained_type(&ptr)? {
+                    Type::FuncProto(proto) => proto,
+                    _ => bail!("Function {} does not have a prototype", target),
+                }
+            }
+            ProbeType::Max => bail!("Invalid probe type"),
+        })
+    }
+
+    fn is_param_type(&self, param: &btf_rs::Parameter, r#type: &str) -> Result<bool> {
+        let mut resolved = self.btf.resolve_chained_type(param)?;
+        let mut full_name = String::new();
+
+        // First, traverse the type definition until we find the actual type.
+        // Only support valid resolve_chained_type calls and exclude function
+        // pointers, static/global variables and especially typedef as we don't
+        // want to traverse its full definition!
+        let mut is_pointer = false;
+        loop {
+            resolved = match resolved {
+                Type::Ptr(t) => {
+                    is_pointer = true;
+                    self.btf.resolve_chained_type(&t)?
+                }
+                Type::Volatile(t) => {
+                    full_name.push_str("volatile ");
+                    self.btf.resolve_chained_type(&t)?
+                }
+                Type::Const(t) => {
+                    full_name.push_str("const ");
+                    self.btf.resolve_chained_type(&t)?
+                }
+                Type::Array(_) => bail!("Arrays are not supported at the moment"),
+                _ => break,
+            }
+        }
+
+        // Then resolve the type name.
+        let type_name = match resolved {
+            Type::Int(t) => self.btf.resolve_name(&t)?,
+            Type::Struct(t) => format!("struct {}", self.btf.resolve_name(&t)?),
+            Type::Union(t) => format!("union {}", self.btf.resolve_name(&t)?),
+            Type::Enum(t) => format!("enum {}", self.btf.resolve_name(&t)?),
+            Type::Typedef(t) => self.btf.resolve_name(&t)?,
+            Type::Float(t) => self.btf.resolve_name(&t)?,
+            Type::Enum64(t) => format!("enum {}", self.btf.resolve_name(&t)?),
+            _ => return Ok(false),
+        };
+        full_name.push_str(type_name.as_str());
+
+        // Set the pointer information C style.
+        if is_pointer {
+            full_name.push_str(" *");
+        }
+
+        // We do not get the symbol name; useless and not always there (e.g.
+        // raw tracepoints).
+
+        Ok(r#type == full_name)
+    }
+
+    /// Get a kernel symbol address given a function name and its type. If the
+    /// symbol isn't found or isn't traceable an error is returned.
+    pub(crate) fn get_ksym(&self, r#type: &ProbeType, target: &str) -> Result<u64> {
+        // Some probe types might need to modify the target format.
+        let ksym_target = match r#type {
+            ProbeType::Kprobe => target.to_string(),
+            ProbeType::RawTracepoint => format!("__tracepoint_{}", target),
+            ProbeType::Max => bail!("Invalid probe type"),
+        };
+
+        kernel_symbols::get_symbol_addr(ksym_target.as_str())
+    }
+
+    /// Inspect a target using BTF and fill its description.
+    pub(super) fn inspect_target(&self, r#type: &ProbeType, target: &str) -> Result<TargetDesc> {
+        // First look at the symbol address.
+        let mut desc = TargetDesc {
+            ksym: self.get_ksym(r#type, target)?,
+            ..Default::default()
+        };
+
+        // Raw tracepoints have a void* pointing to the data as their first
+        // argument, which does not end up in their context. We have to skip it.
+        // See include/trace/bpf_probe.h in the __DEFINE_EVENT definition.
+        let fix = match r#type {
+            &ProbeType::RawTracepoint => 1,
+            _ => 0,
+        };
+
+        // Get parameter offsets.
+        let proto = self.get_function_prototype(r#type, target)?;
+        desc.nargs = (proto.parameters.len() - fix) as u32;
+
+        for (offset, param) in proto.parameters.iter().enumerate() {
+            if offset < fix {
+                continue;
+            }
+            if self.is_param_type(param, "struct sk_buff *")? {
+                desc.probe_cfg.offsets.sk_buff = (offset - fix) as i8;
+            } else if self.is_param_type(param, "enum skb_drop_reason")? {
+                desc.probe_cfg.offsets.skb_drop_reason = (offset - fix) as i8;
+            } else if self.is_param_type(param, "struct net_device *")? {
+                desc.probe_cfg.offsets.net_device = (offset - fix) as i8;
+            } else if self.is_param_type(param, "struct net *")? {
+                desc.probe_cfg.offsets.net = (offset - fix) as i8;
+            }
+        }
+
+        Ok(desc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parameter_offset() {
+        let inspect = Inspector::new().unwrap();
+
+        assert!(
+            inspect
+                .function_parameter_offset(
+                    ProbeType::Kprobe,
+                    "kfree_skb_reason",
+                    "struct sk_buff *"
+                )
+                .unwrap()
+                == Some(0)
+        );
+        assert!(
+            inspect
+                .function_parameter_offset(ProbeType::Kprobe, "kfree_skb_reason", "struct sk_buff")
+                .unwrap()
+                == None
+        );
+
+        assert!(
+            inspect
+                .function_parameter_offset(
+                    ProbeType::RawTracepoint,
+                    "kfree_skb",
+                    "struct sk_buff *"
+                )
+                .unwrap()
+                == Some(0)
+        );
+        assert!(
+            inspect
+                .function_parameter_offset(
+                    ProbeType::RawTracepoint,
+                    "kfree_skb",
+                    "enum skb_drop_reason"
+                )
+                .unwrap()
+                == Some(2)
+        );
+    }
+
+    #[test]
+    fn inspect_target() {
+        let inspect = Inspector::new().unwrap();
+
+        let desc = inspect.inspect_target(&ProbeType::RawTracepoint, "kfree_skb");
+        assert!(desc.is_ok());
+
+        let desc = desc.unwrap();
+        assert!(desc.ksym == 0xffffffff983c29a0);
+        assert!(desc.nargs == 3);
+        assert!(desc.probe_cfg.offsets.sk_buff == 0);
+        assert!(desc.probe_cfg.offsets.skb_drop_reason == 2);
+        assert!(desc.probe_cfg.offsets.net_device == -1);
+        assert!(desc.probe_cfg.offsets.net == -1);
+    }
+}

--- a/src/core/probe/kernel/inspect.rs
+++ b/src/core/probe/kernel/inspect.rs
@@ -6,10 +6,14 @@ use btf_rs::{Btf, Type};
 use super::{config::ProbeConfig, ProbeType};
 use crate::core::kernel_symbols;
 
+/// Holds the result of a kernel symbol inspection and describes it.
 #[derive(Default)]
 pub(super) struct TargetDesc {
+    /// Symbol address.
     pub(super) ksym: u64,
+    /// Number of arguments the symbol has.
     pub(super) nargs: u32,
+    /// Holds the different offsets to known parameters.
     pub(super) probe_cfg: ProbeConfig,
 }
 

--- a/src/core/probe/kernel/kernel.rs
+++ b/src/core/probe/kernel/kernel.rs
@@ -400,10 +400,10 @@ mod tests {
         assert!(kernel.add_probe(ProbeType::Kprobe, "consume_skb").is_ok());
 
         assert!(kernel
-            .add_probe(ProbeType::RawTracepoint, "kfree_skb")
+            .add_probe(ProbeType::RawTracepoint, "skb:kfree_skb")
             .is_ok());
         assert!(kernel
-            .add_probe(ProbeType::RawTracepoint, "kfree_skb")
+            .add_probe(ProbeType::RawTracepoint, "skb:kfree_skb")
             .is_ok());
     }
 
@@ -422,13 +422,13 @@ mod tests {
             .is_ok());
 
         kernel
-            .add_probe(ProbeType::RawTracepoint, "kfree_skb")
+            .add_probe(ProbeType::RawTracepoint, "skb:kfree_skb")
             .unwrap();
         assert!(kernel
-            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "kfree_skb")
+            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "skb:kfree_skb")
             .is_ok());
         assert!(kernel
-            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "kfree_skb")
+            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "skb:kfree_skb")
             .is_ok());
 
         for _ in 0..HOOK_MAX - 4 {
@@ -447,7 +447,7 @@ mod tests {
             .register_hook_to(Hook::from(HOOK), ProbeType::Kprobe, "kfree_skb_reason")
             .is_err());
         assert!(kernel
-            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "kfree_skb")
+            .register_hook_to(Hook::from(HOOK), ProbeType::RawTracepoint, "skb:kfree_skb")
             .is_err());
     }
 

--- a/src/core/probe/kernel/kprobe.rs
+++ b/src/core/probe/kernel/kprobe.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{anyhow, bail, Result};
 
-use super::*;
+use super::{inspect::TargetDesc, *};
 use crate::core::probe::get_ebpf_debug;
 
 mod kprobe_bpf {

--- a/src/core/probe/kernel/mod.rs
+++ b/src/core/probe/kernel/mod.rs
@@ -24,5 +24,6 @@ pub(crate) mod kernel;
 pub(crate) use kernel::*;
 
 mod config;
+mod inspect;
 mod kprobe;
 mod raw_tracepoint;

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{anyhow, Result};
 
-use super::*;
+use super::{inspect::TargetDesc, *};
 use crate::core::probe::get_ebpf_debug;
 
 mod raw_tracepoint_bpf {

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -5,7 +5,7 @@
 //! in two parts, the Rust code (here) and the eBPF one
 //! (bpf/raw_tracepoint.bpf.c and its auto-generated part in bpf/.out/).
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 
 use super::{inspect::TargetDesc, *};
 use crate::core::probe::get_ebpf_debug;
@@ -34,6 +34,12 @@ impl ProbeBuilder for RawTracepointBuilder {
     }
 
     fn attach(&mut self, target: &str, desc: &TargetDesc) -> Result<()> {
+        // Raw tracepoints should have a group:target format.
+        let target = match target.split_once(':') {
+            Some((_, tgt)) => tgt,
+            None => bail!("Invalid tracepoint format for {}", target),
+        };
+
         let mut skel = RawTracepointSkelBuilder::default();
         skel.obj_builder.debug(get_ebpf_debug());
         let mut skel = skel.open()?;
@@ -71,8 +77,8 @@ mod tests {
         let desc = TargetDesc::default();
 
         assert!(builder.init(Vec::new(), Vec::new()).is_ok());
-        assert!(builder.attach("kfree_skb", &desc).is_ok());
-        assert!(builder.attach("consume_skb", &desc).is_ok());
-        assert!(builder.attach("foobar", &desc).is_err());
+        assert!(builder.attach("skb:kfree_skb", &desc).is_ok());
+        assert!(builder.attach("skb:consume_skb", &desc).is_ok());
+        assert!(builder.attach("skb:foobar", &desc).is_err());
     }
 }

--- a/src/core/workaround.rs
+++ b/src/core/workaround.rs
@@ -1,0 +1,122 @@
+/// # Workaround
+///
+/// Provides workarounds to circumvent some limitations of Rust and/or
+/// dependencies we use.
+///
+/// Currently libbpf_rs does not implement Send for many of its objects, while
+/// for some of them it is actually safe. In the meantime, SendWrapper objects
+/// can be used to send a non-Send libbpf_rs object to another thread.
+///
+/// For now we support SendWrapperMap.
+
+/// SendWrapper<T> should not be used directly but only specific typedefs ones.
+/// When adding a new SendWrapper type research should be done to ensure this is
+/// actually safe!
+///
+/// SendWrapper<T> only implements the Send trait, if Sync is needed and more
+/// than one user wants access use the common Arc<Mutex<SendWrapper<T>>>
+/// construction (see core::workaround::tests::sync).
+pub(crate) struct SendWrapper<T>(T)
+where
+    T: Sized + self::private::Sealed;
+
+impl<T> SendWrapper<T>
+where
+    T: Sized + self::private::Sealed,
+{
+    /// Construct a new SendWrapper object given another (Sized) object that
+    /// will become the inner object.
+    pub(crate) fn from(obj: T) -> SendWrapper<T> {
+        SendWrapper(obj)
+    }
+
+    /// Get a reference to the inner object.
+    #[allow(dead_code)]
+    pub(crate) fn get(&self) -> &T {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner object.
+    #[allow(dead_code)]
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+unsafe impl<T: self::private::Sealed> Send for SendWrapper<T> {}
+
+// Define below types where it is actually safe to send them to another thread.
+pub(crate) type SendableMap = SendWrapper<libbpf_rs::Map>;
+
+/// We use a sealed trait to restrict the use of SendWrapper to carefully
+/// allowed types.
+///
+/// This is similar to (but here we're restricting a generic type):
+/// https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
+mod private {
+    pub trait Sealed {}
+
+    // Do not add anything else here unless:
+    // 1. It is absolutely necessary! We reserve the right to refuse additions
+    //    here for any reason.
+    // 2. The long-term plan is to fix the upstream library.
+    impl Sealed for libbpf_rs::Map {}
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        thread,
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct DummyObject {
+        a: u32,
+    }
+
+    impl private::Sealed for DummyObject {}
+
+    #[test]
+    fn send() {
+        let mut sw = SendWrapper::from(DummyObject::default());
+        let mut obj = sw.get_mut();
+        obj.a = 42;
+
+        // No need to test moving the above to > 1 thread fails as the compiler
+        // will throw an error in such case (value used after move).
+        let handle = thread::spawn(move || {
+            let obj = sw.get_mut();
+            assert!(obj.a == 42);
+            obj.a += 1;
+            assert!(obj.a == 43);
+        });
+
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn sync() {
+        let sw = Arc::new(Mutex::new(SendWrapper::from(DummyObject::default())));
+        let mut handles = Vec::new();
+
+        for _ in 0..10 {
+            let sw = Arc::clone(&sw);
+            handles.push(thread::spawn(move || {
+                let mut sw = sw.lock().unwrap();
+                let obj = sw.get_mut();
+                obj.a += 1;
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let sw = sw.lock().unwrap();
+        let obj = sw.get();
+        assert!(obj.a == 10);
+    }
+}


### PR DESCRIPTION
This adds a collector which will track skbs and generate a unique id so we can recognize a collector later in the stack and reconstruct its life at post-processing time (or manually looking at the events; once available).

Some extra commits to make the tracking collector easier to implement. More info in the commit themselves.

Based on #50.