### PR TITLE
Initial support for skb data retrieval (aka skb module events)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,7 @@ fn main() {
     build_probe("src/core/probe/kernel/bpf/raw_tracepoint.bpf.c");
     build_probe("src/core/probe/user/bpf/usdt.bpf.c");
 
-    // module::skb_tracking
+    build_hook("src/module/skb/bpf/skb_hook.bpf.c");
     build_hook("src/module/skb_tracking/bpf/tracking_hook.bpf.c");
     build_hook("src/module/ovs/bpf/main_hook.bpf.c");
 

--- a/src/core/events/bpf.rs
+++ b/src/core/events/bpf.rs
@@ -369,6 +369,7 @@ pub(crate) enum BpfEventOwner {
     Kernel = 2,
     Userspace = 3,
     CollectorSkbTracking = 4,
+    CollectorSkb = 5,
 }
 
 impl BpfEventOwner {
@@ -379,6 +380,7 @@ impl BpfEventOwner {
             2 => Kernel,
             3 => Userspace,
             4 => CollectorSkbTracking,
+            5 => CollectorSkb,
             x => bail!("Can't construct a BpfEventOwner from {}", x),
         };
         Ok(owner)
@@ -391,6 +393,7 @@ impl BpfEventOwner {
             Kernel => "kernel",
             Userspace => "userspace",
             CollectorSkbTracking => "skb-tracking",
+            CollectorSkb => "skb",
         };
         Ok(ret)
     }

--- a/src/core/events/bpf.rs
+++ b/src/core/events/bpf.rs
@@ -278,6 +278,22 @@ fn parse_raw_event(data: &[u8], unmarshalers: &Unmarshalers, cache: &mut Cache) 
     Ok(event)
 }
 
+/// Helper to check a raw section validity and parse it into a structured type.
+pub(crate) fn parse_raw_section<T>(raw_section: &BpfRawSection) -> Result<T>
+where
+    T: Default + Plain,
+{
+    if raw_section.data.len() != mem::size_of::<T>() {
+        bail!("Section data is not the expected size");
+    }
+
+    let mut event = T::default();
+    plain::copy_from_bytes(&mut event, &raw_section.data)
+        .or_else(|_| bail!("Could not parse the raw section"))?;
+
+    Ok(event)
+}
+
 // We use a dummy implementation of BpfEvents to allow unit tests to pass.
 // This is fine as no function in the above can really be tested.
 #[cfg(test)]

--- a/src/core/events/bpf/include/events.h
+++ b/src/core/events/bpf/include/events.h
@@ -13,6 +13,7 @@ enum trace_event_owners {
 	KERNEL = 2,
 	USERSPACE = 3,
 	COLLECTOR_SKB_TRACKING = 4,
+	COLLECTOR_SKB = 5,
 };
 
 struct trace_raw_event {

--- a/src/core/events/bpf/include/events.h
+++ b/src/core/events/bpf/include/events.h
@@ -76,6 +76,19 @@ static __always_inline void *get_event_section(struct trace_raw_event *event,
 	return section;
 }
 
+/* Similar to get_event_section but initialize the section data to 0s. */
+static __always_inline void *get_event_zsection(struct trace_raw_event *event,
+						u8 owner, u8 data_type, const u16 size)
+{
+	void *section = get_event_section(event, owner, data_type, size);
+
+	if (!section)
+		return NULL;
+
+	__builtin_memset(section, 0, size);
+	return section;
+}
+
 struct common_event {
 	u64 timestamp;
 } __attribute__((packed));

--- a/src/core/events/events.rs
+++ b/src/core/events/events.rs
@@ -174,8 +174,12 @@ macro_rules! event_field_type {
 }
 
 // Common types definition.
+event_field_type!(u8);
+event_field_type!(u16);
 event_field_type!(u32);
 event_field_type!(u64);
+event_field_type!(i8);
+event_field_type!(i16);
 event_field_type!(i32);
 event_field_type!(i64);
 event_field_type!(String);

--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -20,14 +20,14 @@ struct trace_probe_offsets {
 	s8 skb_drop_reason;
 	s8 net_device;
 	s8 net;		/* netns */
-};
+} __attribute__((packed));
 
 /* Per-probe configuration; keep in sync with its Rust counterpart in
  * core::probe::kernel::config.
  */
 struct trace_probe_config {
 	struct trace_probe_offsets offsets;
-};
+} __attribute__((packed));
 
 /* Keep in sync with its Rust counterpart in crate::core::probe::kernel */
 #define PROBE_MAX	128

--- a/src/core/probe/kernel/config.rs
+++ b/src/core/probe/kernel/config.rs
@@ -6,7 +6,7 @@ use crate::core::probe::PROBE_MAX;
 
 /// Per-probe parameter offsets; keep in sync with its BPF counterpart in
 /// bpf/include/common.h
-#[repr(C)]
+#[repr(C, packed)]
 pub(super) struct ProbeOffsets {
     pub(super) sk_buff: i8,
     pub(super) skb_drop_reason: i8,
@@ -29,7 +29,7 @@ impl Default for ProbeOffsets {
 /// Per-probe configuration; keep in sync with its BPF counterpart in
 /// bpf/include/common.h
 #[derive(Default)]
-#[repr(C)]
+#[repr(C, packed)]
 pub(crate) struct ProbeConfig {
     pub(super) offsets: ProbeOffsets,
 }

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -4,6 +4,8 @@
 //!
 //! Please keep this file in sync with its BPF counterpart in bpf/skb_hook.bpf.c
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use anyhow::Result;
 use plain::Plain;
 
@@ -18,6 +20,8 @@ use crate::{
 /// Valid raw event sections of the skb collector. We do not use an enum here as
 /// they are difficult to work with for bitfields and C repr conversion.
 pub(super) const SECTION_L2: u64 = 0;
+pub(super) const SECTION_IPV4: u64 = 1;
+pub(super) const SECTION_IPV6: u64 = 2;
 
 /// Global configuration passed down the BPF part.
 #[repr(C, packed)]
@@ -61,6 +65,72 @@ pub(super) fn unmarshal_l2(
             event.dst[0], event.dst[1], event.dst[2], event.dst[3], event.dst[4], event.dst[5],
         )
     ));
+
+    Ok(())
+}
+
+/// IPv4 data retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbIpv4Event {
+    /// Source IP address. Stored in network order.
+    src: u32,
+    /// Destination IP address. Stored in network order.
+    dst: u32,
+    /// IP packet length in bytes. Stored in network order.
+    len: u16,
+    /// L4 protocol.
+    protocol: u8,
+}
+unsafe impl Plain for SkbIpv4Event {}
+
+pub(super) fn unmarshal_ipv4(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbIpv4Event>(raw_section)?;
+
+    let src = Ipv4Addr::from(u32::from_be(event.src));
+    fields.push(event_field!("saddr", format!("{src}")));
+    let dst = Ipv4Addr::from(u32::from_be(event.dst));
+    fields.push(event_field!("daddr", format!("{dst}")));
+
+    fields.push(event_field!("ip_version", 4));
+    fields.push(event_field!("l3_len", u16::from_be(event.len)));
+    fields.push(event_field!("protocol", event.protocol));
+
+    Ok(())
+}
+
+/// IPv6 data retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbIpv6Event {
+    /// Source IP address. Stored in network order.
+    src: u128,
+    /// Destination IP address. Stored in network order.
+    dst: u128,
+    /// IP packet length in bytes. Stored in network order.
+    len: u16,
+    /// L4 protocol.
+    protocol: u8,
+}
+unsafe impl Plain for SkbIpv6Event {}
+
+pub(super) fn unmarshal_ipv6(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbIpv6Event>(raw_section)?;
+
+    let src = Ipv6Addr::from(u128::from_be(event.src));
+    fields.push(event_field!("saddr", format!("{src}")));
+    let dst = Ipv6Addr::from(u128::from_be(event.dst));
+    fields.push(event_field!("daddr", format!("{dst}")));
+
+    fields.push(event_field!("ip_version", 6));
+    fields.push(event_field!("l3_len", u16::from_be(event.len)));
+    fields.push(event_field!("protocol", event.protocol));
 
     Ok(())
 }

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -24,6 +24,7 @@ pub(super) const SECTION_IPV4: u64 = 1;
 pub(super) const SECTION_IPV6: u64 = 2;
 pub(super) const SECTION_TCP: u64 = 3;
 pub(super) const SECTION_UDP: u64 = 4;
+pub(super) const SECTION_ICMP: u64 = 5;
 
 /// Global configuration passed down the BPF part.
 #[repr(C, packed)]
@@ -196,6 +197,29 @@ pub(super) fn unmarshal_udp(
     fields.push(event_field!("sport", u16::from_be(event.sport)));
     fields.push(event_field!("dport", u16::from_be(event.dport)));
     fields.push(event_field!("udp_len", u16::from_be(event.len)));
+
+    Ok(())
+}
+
+/// ICMP data retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbIcmpEvent {
+    /// ICMP type.
+    r#type: u8,
+    /// ICMP sub-type.
+    code: u8,
+}
+unsafe impl Plain for SkbIcmpEvent {}
+
+pub(super) fn unmarshal_icmp(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbIcmpEvent>(raw_section)?;
+
+    fields.push(event_field!("icmp_type", event.r#type));
+    fields.push(event_field!("icmp_code", event.code));
 
     Ok(())
 }

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -30,6 +30,7 @@ pub(super) const SECTION_UDP: u64 = 4;
 pub(super) const SECTION_ICMP: u64 = 5;
 pub(super) const SECTION_DEV: u64 = 6;
 pub(super) const SECTION_NS: u64 = 7;
+pub(super) const SECTION_DATA_REF: u64 = 8;
 
 /// Global configuration passed down the BPF part.
 #[repr(C, packed)]
@@ -278,5 +279,34 @@ pub(super) fn unmarshal_ns(
 ) -> Result<()> {
     let event = parse_raw_section::<SkbNsEvent>(raw_section)?;
     fields.push(event_field!("netns", event.netns));
+    Ok(())
+}
+
+/// Data & refcount information retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbDataRefEvent {
+    /// Is the skb a clone?
+    cloned: u8,
+    /// Is the skb a fast clone?
+    fclone: u8,
+    /// Users count.
+    users: u8,
+    /// Data refcount.
+    dataref: u8,
+}
+unsafe impl Plain for SkbDataRefEvent {}
+
+pub(super) fn unmarshal_data_ref(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbDataRefEvent>(raw_section)?;
+
+    fields.push(event_field!("cloned", event.cloned));
+    fields.push(event_field!("fclone", event.fclone));
+    fields.push(event_field!("users", event.users));
+    fields.push(event_field!("dataref", event.dataref));
+
     Ok(())
 }

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -29,6 +29,7 @@ pub(super) const SECTION_TCP: u64 = 3;
 pub(super) const SECTION_UDP: u64 = 4;
 pub(super) const SECTION_ICMP: u64 = 5;
 pub(super) const SECTION_DEV: u64 = 6;
+pub(super) const SECTION_NS: u64 = 7;
 
 /// Global configuration passed down the BPF part.
 #[repr(C, packed)]
@@ -259,5 +260,23 @@ pub(super) fn unmarshal_dev(
         fields.push(event_field!("rx_ifindex", event.iif));
     }
 
+    Ok(())
+}
+
+/// Net namespace information retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbNsEvent {
+    /// Net namespace id.
+    netns: u32,
+}
+unsafe impl Plain for SkbNsEvent {}
+
+pub(super) fn unmarshal_ns(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbNsEvent>(raw_section)?;
+    fields.push(event_field!("netns", event.netns));
     Ok(())
 }

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -1,0 +1,66 @@
+//! Rust<>BPF types definitions for the skb module. Fields are not translated in
+//! the BPF part and can be represented in various orders, depending from where
+//! they come from. Some handling might be needed in the unmarshalers.
+//!
+//! Please keep this file in sync with its BPF counterpart in bpf/skb_hook.bpf.c
+
+use anyhow::Result;
+use plain::Plain;
+
+use crate::{
+    core::events::{
+        bpf::{parse_raw_section, BpfRawSection},
+        EventField,
+    },
+    event_field,
+};
+
+/// Valid raw event sections of the skb collector. We do not use an enum here as
+/// they are difficult to work with for bitfields and C repr conversion.
+pub(super) const SECTION_L2: u64 = 0;
+
+/// Global configuration passed down the BPF part.
+#[repr(C, packed)]
+pub(super) struct SkbConfig {
+    /// Bitfield of what to collect from skbs. Currently `1 << SECTION_x` is
+    /// used to trigger retrieval of a given section.
+    pub sections: u64,
+}
+
+/// L2 data retrieved from skbs.
+#[derive(Default)]
+#[repr(C, packed)]
+struct SkbL2Event {
+    /// Source MAC address.
+    src: [u8; 6],
+    /// Destination MAC address.
+    dst: [u8; 6],
+    /// Ethertype. Stored in network order.
+    etype: u16,
+}
+unsafe impl Plain for SkbL2Event {}
+
+pub(super) fn unmarshal_l2(
+    raw_section: &BpfRawSection,
+    fields: &mut Vec<EventField>,
+) -> Result<()> {
+    let event = parse_raw_section::<SkbL2Event>(raw_section)?;
+
+    fields.push(event_field!("etype", u16::from_be(event.etype)));
+    fields.push(event_field!(
+        "src",
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            event.src[0], event.src[1], event.src[2], event.src[3], event.src[4], event.src[5],
+        )
+    ));
+    fields.push(event_field!(
+        "dst",
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            event.dst[0], event.dst[1], event.dst[2], event.dst[3], event.dst[4], event.dst[5],
+        )
+    ));
+
+    Ok(())
+}

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -1,0 +1,10 @@
+#include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
+
+#include <common.h>
+
+DEFINE_HOOK(
+	return 0;
+)
+
+char __license[] SEC("license") = "GPL";

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -13,6 +13,8 @@
 #define COLLECT_L2		0
 #define COLLECT_IPV4		1
 #define COLLECT_IPV6		2
+#define COLLECT_TCP		3
+#define COLLECT_UDP		4
 
 /* Skb hook configuration. A map is used to set the config from userspace.
  *
@@ -47,6 +49,21 @@ struct skb_ipv6_event {
 	u128 dst;
 	u16 len;
 	u8 protocol;
+} __attribute__((packed));
+struct skb_tcp_event {
+	u16 sport;
+	u16 dport;
+	u32 seq;
+	u32 ack_seq;
+	u16 window;
+	/* TCP flags: fin, syn, rst, psh, ack, urg, ece, cwr. */
+	u8 flags;
+	u8 doff;
+} __attribute__((packed));
+struct skb_udp_event {
+	u16 sport;
+	u16 dport;
+	u16 len;
 } __attribute__((packed));
 
 /* Must be called with a valid skb pointer */
@@ -136,6 +153,50 @@ static __always_inline int process_skb_l2_l4(struct trace_context *ctx,
 		}
 	} else {
 		return 0;
+	}
+
+	/* L4 */
+
+	transport = BPF_CORE_READ(skb, transport_header);
+	if (!transport || transport == mac || transport == network ||
+	    transport == (u16)~0U)
+		return 0;
+
+	if (protocol == IPPROTO_TCP && cfg->sections & BIT(COLLECT_TCP)) {
+		struct tcphdr *tcp = (struct tcphdr *)(head + transport);
+		struct skb_tcp_event *e =
+			get_event_section(event, COLLECTOR_SKB, COLLECT_TCP,
+					  sizeof(*e));
+		if (!e)
+			return 0;
+
+		bpf_probe_read_kernel(&e->sport, sizeof(e->sport), &tcp->source);
+		bpf_probe_read_kernel(&e->dport, sizeof(e->dport), &tcp->dest);
+		bpf_probe_read_kernel(&e->seq, sizeof(e->seq), &tcp->seq);
+		bpf_probe_read_kernel(&e->ack_seq, sizeof(e->ack_seq), &tcp->ack_seq);
+		bpf_probe_read_kernel(&e->window, sizeof(e->window), &tcp->window);
+
+		e->flags = (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, fin);
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, syn) << 1;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, rst) << 2;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, psh) << 3;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, ack) << 4;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, urg) << 5;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, ece) << 6;
+		e->flags |= (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, cwr) << 7;
+
+		e->doff = (u8)BPF_CORE_READ_BITFIELD_PROBED(tcp, doff);
+	} else if (protocol == IPPROTO_UDP && cfg->sections & BIT(COLLECT_UDP)) {
+		struct udphdr *udp = (struct udphdr *)(head + transport);
+		struct skb_udp_event *e =
+			get_event_section(event, COLLECTOR_SKB, COLLECT_UDP,
+					  sizeof(*e));
+		if (!e)
+			return 0;
+
+		bpf_probe_read_kernel(&e->sport, sizeof(e->sport), &udp->source);
+		bpf_probe_read_kernel(&e->dport, sizeof(e->dport), &udp->dest);
+		bpf_probe_read_kernel(&e->len, sizeof(e->len), &udp->len);
 	}
 
 	return 0;

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -1,9 +1,104 @@
 #include <vmlinux.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
 
 #include <common.h>
 
+#define BIT(x) (1 << (x))
+
+/* Skb raw event sections.
+ *
+ * Please keep in sync with its Rust counterpart in module::skb::bpf.
+ */
+#define COLLECT_L2		0
+
+/* Skb hook configuration. A map is used to set the config from userspace.
+ *
+ * Please keep in sync with its Rust counterpart in module::skb::bpf.
+ */
+struct skb_config {
+	u64 sections;
+} __attribute__((packed));
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, sizeof(struct skb_config));
+} skb_config_map SEC(".maps");
+
+/* Please keep the following structs in sync with its Rust counterpart in
+ * module::skb::bpf.
+ */
+struct skb_l2_event {
+	u8 dst[6];
+	u8 src[6];
+	u16 etype;
+} __attribute__((packed));
+
+/* Must be called with a valid skb pointer */
+static __always_inline int process_skb_l2_l4(struct trace_context *ctx,
+					     struct event *event,
+					     struct skb_config *cfg,
+					     struct sk_buff *skb)
+{
+	unsigned char *head = BPF_CORE_READ(skb, head);
+	u16 mac, network, transport, etype;
+	u8 protocol, ip_version;
+
+	/* L2 */
+
+	mac = BPF_CORE_READ(skb, mac_header);
+	etype = BPF_CORE_READ(skb, protocol);
+
+	/* If the ethertype isn't set, bail out early as we can't process such
+	 * packets below.
+	 */
+	if (etype == 0)
+		return 0;
+
+	if (cfg->sections & BIT(COLLECT_L2)) {
+		struct skb_l2_event *e =
+			get_event_zsection(event, COLLECTOR_SKB, COLLECT_L2,
+					   sizeof(*e));
+		if (!e)
+			return 0;
+
+		if (mac != (u16)~0U) {
+			struct ethhdr *eth = (struct ethhdr *)(head + mac);
+
+			bpf_probe_read_kernel(e->src, sizeof(e->src), eth->h_source);
+			bpf_probe_read_kernel(e->dst, sizeof(e->dst), eth->h_dest);
+		}
+
+		e->etype = etype;
+	}
+
+	return 0;
+}
+
+/* Must be called with a valid skb pointer */
+static __always_inline int process_skb(struct trace_context *ctx,
+				       struct event *event, struct sk_buff *skb)
+{
+	struct skb_shared_info *si;
+	struct skb_config *cfg;
+	struct net_device *dev;
+	u32 key = 0;
+
+	cfg = bpf_map_lookup_elem(&skb_config_map, &key);
+	if (!cfg)
+		return 0;
+
+	return process_skb_l2_l4(ctx, event, cfg, skb);
+}
+
 DEFINE_HOOK(
+	struct sk_buff *skb;
+
+	skb = trace_get_sk_buff(ctx);
+	if (skb)
+		process_skb(ctx, event, skb);
+
 	return 0;
 )
 

--- a/src/module/skb/mod.rs
+++ b/src/module/skb/mod.rs
@@ -1,10 +1,12 @@
 //! # SkbCollector
 //!
-//! Provide a generic way to probe kernel functions and tracepoints (having a
-//! `struct sk_buff *` as a parameter), to filter skbs, and to track them;
-//! allowing to reconstruct their path in the Linux networking stack.
+//! Provide support for retrieving data from `struct sk_buff` kernel objects.
 
 // Re-export skb.rs
 #[allow(clippy::module_inception)]
 pub(crate) mod skb;
 pub(crate) use skb::*;
+
+mod skb_hook {
+    include!("bpf/.out/skb_hook.rs");
+}

--- a/src/module/skb/mod.rs
+++ b/src/module/skb/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod skb;
 pub(crate) use skb::*;
 
+mod bpf;
 mod skb_hook {
     include!("bpf/.out/skb_hook.rs");
 }

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 
+use super::skb_hook;
 use crate::{
     cli::{dynamic::DynamicCommand, CliConfig},
     collect::Collector,
-    core::{events::bpf::BpfEvents, probe::ProbeManager},
+    core::{events::bpf::BpfEvents, probe::{ProbeManager, Hook}},
 };
 
 const SKB_COLLECTOR: &str = "skb";
@@ -20,7 +21,7 @@ impl Collector for SkbCollector {
     }
 
     fn known_kernel_types(&self) -> Option<Vec<&'static str>> {
-        None
+        Some(vec!["struct sk_buff *"])
     }
 
     fn register_cli(&self, cmd: &mut DynamicCommand) -> Result<()> {
@@ -30,9 +31,10 @@ impl Collector for SkbCollector {
     fn init(
         &mut self,
         _: &CliConfig,
-        _probes: &mut ProbeManager,
+        probes: &mut ProbeManager,
         _events: &mut BpfEvents,
     ) -> Result<()> {
+        probes.register_kernel_hook(Hook::from(skb_hook::DATA))?;
         Ok(())
     }
 

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,9 +19,9 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2", "l3"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp"]),
         value_delimiter=',',
-        default_value="l3",
+        default_value="l3,tcp,udp",
         help = "Comma separated list of data to collect from skbs"
     )]
     skb_sections: Vec<String>,
@@ -61,6 +61,8 @@ impl Collector for SkbCollector {
                 "all" => sections |= !0_u64,
                 "l2" => sections |= 1 << SECTION_L2,
                 "l3" => sections |= 1 << SECTION_IPV4 | 1 << SECTION_IPV6,
+                "tcp" => sections |= 1 << SECTION_TCP,
+                "udp" => sections |= 1 << SECTION_UDP,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -73,6 +75,8 @@ impl Collector for SkbCollector {
                     SECTION_L2 => unmarshal_l2(raw_section, fields),
                     SECTION_IPV4 => unmarshal_ipv4(raw_section, fields),
                     SECTION_IPV6 => unmarshal_ipv6(raw_section, fields),
+                    SECTION_TCP => unmarshal_tcp(raw_section, fields),
+                    SECTION_UDP => unmarshal_udp(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,9 +19,9 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp"]),
         value_delimiter=',',
-        default_value="l3,tcp,udp",
+        default_value="l3,tcp,udp,icmp",
         help = "Comma separated list of data to collect from skbs"
     )]
     skb_sections: Vec<String>,
@@ -63,6 +63,7 @@ impl Collector for SkbCollector {
                 "l3" => sections |= 1 << SECTION_IPV4 | 1 << SECTION_IPV6,
                 "tcp" => sections |= 1 << SECTION_TCP,
                 "udp" => sections |= 1 << SECTION_UDP,
+                "icmp" => sections |= 1 << SECTION_ICMP,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -77,6 +78,7 @@ impl Collector for SkbCollector {
                     SECTION_IPV6 => unmarshal_ipv6(raw_section, fields),
                     SECTION_TCP => unmarshal_tcp(raw_section, fields),
                     SECTION_UDP => unmarshal_udp(raw_section, fields),
+                    SECTION_ICMP => unmarshal_icmp(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,7 +19,7 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp", "dev", "ns"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp", "dev", "ns", "dataref"]),
         value_delimiter=',',
         default_value="l3,tcp,udp,icmp",
         help = "Comma separated list of data to collect from skbs"
@@ -66,6 +66,7 @@ impl Collector for SkbCollector {
                 "icmp" => sections |= 1 << SECTION_ICMP,
                 "dev" => sections |= 1 << SECTION_DEV,
                 "ns" => sections |= 1 << SECTION_NS,
+                "dataref" => sections |= 1 << SECTION_DATA_REF,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -83,6 +84,7 @@ impl Collector for SkbCollector {
                     SECTION_ICMP => unmarshal_icmp(raw_section, fields),
                     SECTION_DEV => unmarshal_dev(raw_section, fields),
                     SECTION_NS => unmarshal_ns(raw_section, fields),
+                    SECTION_DATA_REF => unmarshal_data_ref(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -1,13 +1,31 @@
-use anyhow::Result;
+use std::mem;
 
-use super::skb_hook;
+use anyhow::{bail, Result};
+use clap::{arg, builder::PossibleValuesParser, Parser};
+
+use super::{bpf::*, skb_hook};
 use crate::{
     cli::{dynamic::DynamicCommand, CliConfig},
     collect::Collector,
-    core::{events::bpf::BpfEvents, probe::{ProbeManager, Hook}},
+    core::{
+        events::bpf::{BpfEventOwner, BpfEvents},
+        probe::{Hook, ProbeManager},
+    },
 };
 
 const SKB_COLLECTOR: &str = "skb";
+
+#[derive(Parser, Default)]
+pub(crate) struct SkbCollectorArgs {
+    #[arg(
+        long,
+        value_parser=PossibleValuesParser::new(["all", "l2"]),
+        value_delimiter=',',
+        default_value="",
+        help = "Comma separated list of data to collect from skbs"
+    )]
+    skb_sections: Vec<String>,
+}
 
 pub(crate) struct SkbCollector {}
 
@@ -25,20 +43,78 @@ impl Collector for SkbCollector {
     }
 
     fn register_cli(&self, cmd: &mut DynamicCommand) -> Result<()> {
-        cmd.register_module_noargs(SKB_COLLECTOR)
+        cmd.register_module::<SkbCollectorArgs>(SKB_COLLECTOR)
     }
 
     fn init(
         &mut self,
-        _: &CliConfig,
+        cli: &CliConfig,
         probes: &mut ProbeManager,
-        _events: &mut BpfEvents,
+        events: &mut BpfEvents,
     ) -> Result<()> {
-        probes.register_kernel_hook(Hook::from(skb_hook::DATA))?;
+        // First, get the cli parameters.
+        let args = cli.get_section::<SkbCollectorArgs>(SKB_COLLECTOR)?;
+
+        let mut sections: u64 = 0;
+        for category in args.skb_sections.iter() {
+            match category.as_str() {
+                "all" => sections |= !0_u64,
+                "l2" => sections |= 1 << SECTION_L2,
+                x => bail!("Unknown skb_collect value ({})", x),
+            }
+        }
+
+        // Register our event unmarshaler.
+        events.register_unmarshaler(
+            BpfEventOwner::CollectorSkb,
+            Box::new(
+                |raw_section, fields, _| match raw_section.header.data_type as u64 {
+                    SECTION_L2 => unmarshal_l2(raw_section, fields),
+                    _ => bail!("Unknown data type"),
+                },
+            ),
+        )?;
+
+        // Then, create the config map.
+        let mut config_map = Self::config_map()?;
+
+        // Set the config.
+        let cfg = SkbConfig { sections };
+        let cfg = unsafe { plain::as_bytes(&cfg) };
+
+        let key = 0_u32.to_ne_bytes();
+        config_map.update(&key, cfg, libbpf_rs::MapFlags::empty())?;
+
+        // Register our generic skb hook.
+        probes.register_kernel_hook(
+            Hook::from(skb_hook::DATA)
+                .reuse_map("skb_config_map", config_map.fd())?
+                .to_owned(),
+        )?;
         Ok(())
     }
 
     fn start(&mut self) -> Result<()> {
         Ok(())
+    }
+}
+
+impl SkbCollector {
+    fn config_map() -> Result<libbpf_rs::Map> {
+        let opts = libbpf_sys::bpf_map_create_opts {
+            sz: mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+            ..Default::default()
+        };
+
+        // Please keep in sync with its BPF counterpart in bpf/skb_hook.bpf.c
+        libbpf_rs::Map::create(
+            libbpf_rs::MapType::Array,
+            Some("skb_config_map"),
+            mem::size_of::<u32>() as u32,
+            mem::size_of::<SkbConfig>() as u32,
+            1,
+            &opts,
+        )
+        .or_else(|e| bail!("Could not create the skb config map: {}", e))
     }
 }

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,7 +19,7 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp", "dev"]),
         value_delimiter=',',
         default_value="l3,tcp,udp,icmp",
         help = "Comma separated list of data to collect from skbs"
@@ -64,6 +64,7 @@ impl Collector for SkbCollector {
                 "tcp" => sections |= 1 << SECTION_TCP,
                 "udp" => sections |= 1 << SECTION_UDP,
                 "icmp" => sections |= 1 << SECTION_ICMP,
+                "dev" => sections |= 1 << SECTION_DEV,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -79,6 +80,7 @@ impl Collector for SkbCollector {
                     SECTION_TCP => unmarshal_tcp(raw_section, fields),
                     SECTION_UDP => unmarshal_udp(raw_section, fields),
                     SECTION_ICMP => unmarshal_icmp(raw_section, fields),
+                    SECTION_DEV => unmarshal_dev(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,9 +19,9 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3"]),
         value_delimiter=',',
-        default_value="",
+        default_value="l3",
         help = "Comma separated list of data to collect from skbs"
     )]
     skb_sections: Vec<String>,
@@ -60,6 +60,7 @@ impl Collector for SkbCollector {
             match category.as_str() {
                 "all" => sections |= !0_u64,
                 "l2" => sections |= 1 << SECTION_L2,
+                "l3" => sections |= 1 << SECTION_IPV4 | 1 << SECTION_IPV6,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -70,6 +71,8 @@ impl Collector for SkbCollector {
             Box::new(
                 |raw_section, fields, _| match raw_section.header.data_type as u64 {
                     SECTION_L2 => unmarshal_l2(raw_section, fields),
+                    SECTION_IPV4 => unmarshal_ipv4(raw_section, fields),
+                    SECTION_IPV6 => unmarshal_ipv6(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -19,7 +19,7 @@ const SKB_COLLECTOR: &str = "skb";
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp", "dev"]),
+        value_parser=PossibleValuesParser::new(["all", "l2", "l3", "tcp", "udp", "icmp", "dev", "ns"]),
         value_delimiter=',',
         default_value="l3,tcp,udp,icmp",
         help = "Comma separated list of data to collect from skbs"
@@ -65,6 +65,7 @@ impl Collector for SkbCollector {
                 "udp" => sections |= 1 << SECTION_UDP,
                 "icmp" => sections |= 1 << SECTION_ICMP,
                 "dev" => sections |= 1 << SECTION_DEV,
+                "ns" => sections |= 1 << SECTION_NS,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }
@@ -81,6 +82,7 @@ impl Collector for SkbCollector {
                     SECTION_UDP => unmarshal_udp(raw_section, fields),
                     SECTION_ICMP => unmarshal_icmp(raw_section, fields),
                     SECTION_DEV => unmarshal_dev(raw_section, fields),
+                    SECTION_NS => unmarshal_ns(raw_section, fields),
                     _ => bail!("Unknown data type"),
                 },
             ),

--- a/src/module/skb_tracking/bpf/tracking_hook.bpf.c
+++ b/src/module/skb_tracking/bpf/tracking_hook.bpf.c
@@ -8,7 +8,7 @@
  *
  * Indexed in the tracking_config_map by the function ksym address.
  *
- * Please keep in sync with its Rust counterpart in collector::skb_tracking.
+ * Please keep in sync with its Rust counterpart in module::skb_tracking.
  */
 struct tracking_config {
 	/* Function is freeing skbs */
@@ -30,7 +30,7 @@ struct {
  * In order to uniquely identify skbs, the tuple (addr, timestamp) is used and
  * must be reported as part of all events (TODO).
  *
- * Please keep in sync with its Rust counterpart in collector::skb_tracking.
+ * Please keep in sync with its Rust counterpart in module::skb_tracking.
  */
 struct tracking_info {
 	/* When the skb was first seen */

--- a/src/module/skb_tracking/bpf/tracking_hook.bpf.c
+++ b/src/module/skb_tracking/bpf/tracking_hook.bpf.c
@@ -15,7 +15,7 @@ struct tracking_config {
 	u8 free;
 	/* Function is invalidating the head of skbs */
 	u8 inv_head;
-};
+} __attribute__((packed));
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PROBE_MAX);

--- a/src/module/skb_tracking/skb_tracking.rs
+++ b/src/module/skb_tracking/skb_tracking.rs
@@ -125,7 +125,7 @@ impl SkbTrackingCollector {
         };
 
         // Please keep in sync with its BPF counterpart in
-        // bpf/tracking_hook.ebpf.c
+        // bpf/tracking_hook.bpf.c
         libbpf_rs::Map::create(
             libbpf_rs::MapType::Hash,
             Some("tracking_config_map"),
@@ -144,7 +144,7 @@ impl SkbTrackingCollector {
         };
 
         // Please keep in sync with its BPF counterpart in
-        // bpf/tracking_hook.ebpf.c
+        // bpf/tracking_hook.bpf.c
         libbpf_rs::Map::create(
             libbpf_rs::MapType::Hash,
             Some("tracking_map"),
@@ -240,7 +240,7 @@ impl SkbTrackingCollector {
     }
 }
 
-// Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
+// Please keep in sync with its BPF counterpart in bpf/tracking_hook.bpf.c
 #[repr(C, packed)]
 struct TrackingConfig {
     free: u8,
@@ -249,7 +249,7 @@ struct TrackingConfig {
 
 unsafe impl Plain for TrackingConfig {}
 
-// Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
+// Please keep in sync with its BPF counterpart in bpf/tracking_hook.bpf.c
 #[derive(Default)]
 #[repr(C, packed)]
 struct TrackingInfo {

--- a/src/module/skb_tracking/skb_tracking.rs
+++ b/src/module/skb_tracking/skb_tracking.rs
@@ -11,7 +11,7 @@ use crate::{
     collect::Collector,
     core::{
         events::{
-            bpf::{BpfEventOwner, BpfEvents},
+            bpf::{parse_raw_section, BpfEventOwner, BpfEvents},
             EventField,
         },
         kernel::Symbol,
@@ -82,17 +82,7 @@ impl Collector for SkbTrackingCollector {
                     bail!("Unknown data type");
                 }
 
-                if raw_section.data.len() != mem::size_of::<SkbTrackingEvent>() {
-                    bail!(
-                        "Section data is not the expected size {} != {}",
-                        raw_section.data.len(),
-                        mem::size_of::<SkbTrackingEvent>(),
-                    );
-                }
-
-                let mut event = SkbTrackingEvent::default();
-                plain::copy_from_bytes(&mut event, &raw_section.data)
-                    .or_else(|_| bail!("Could not parse the raw section"))?;
+                let event = parse_raw_section::<SkbTrackingEvent>(raw_section)?;
 
                 fields.push(event_field!("orig_head", event.orig_head));
                 fields.push(event_field!("timestamp", event.timestamp));

--- a/src/module/skb_tracking/skb_tracking.rs
+++ b/src/module/skb_tracking/skb_tracking.rs
@@ -241,7 +241,7 @@ impl SkbTrackingCollector {
 }
 
 // Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
-#[repr(C)]
+#[repr(C, packed)]
 struct TrackingConfig {
     free: u8,
     inv_head: u8,
@@ -251,7 +251,7 @@ unsafe impl Plain for TrackingConfig {}
 
 // Please keep in sync with its BPF counterpart in bpf/tracking_hook.ebpf.c
 #[derive(Default)]
-#[repr(C)]
+#[repr(C, packed)]
 struct TrackingInfo {
     timestamp: u64,
     last_seen: u64,


### PR DESCRIPTION
Let's put an emphasis on *initial*:

- Logic to retrieve more data, and/or to get some data from other sources can and will be added later.
- Event field names might change.
- There are probably some corner cases not supported, e.g. probing certain functions means parts of the skb wasn't processed yet and accessing this data might not be possible (w/o implementing a full packet parser) or not set yet fields resulting in invalid data[1].

However I believe this PR is in a good shape to provide an example of what data collection from a module should look like and might trigger some discussions; and good enough to be used already for retrieving common fields in well known L2 to L4 protocols as well as from the skb metadata.

[1] So far I put measures in place to fix the one I know and found.