### PR TITLE
fix include path in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -85,8 +85,11 @@ fn build_probe(source: &str) {
 }
 
 fn gen_bindings() {
+    let (inc_path, _) = BINDGEN_HEADER.rsplit_once('/').unwrap();
+
     bindgen::Builder::default()
         .header(BINDGEN_HEADER)
+        .clang_arg(format!("-I{inc_path}"))
         .default_enum_style(bindgen::EnumVariation::Rust {
             non_exhaustive: false,
         })


### PR DESCRIPTION
bpf_common.h in particular was not included from the vendored files, but the system one was used.
Even though a common strategy for vendored files is probably going to be included, it's useful to fix it for future reference.